### PR TITLE
Correct CURL to include /example path

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ restly.init('./routes.json', {lib: "includes/"});
 Access this route via a HTTP get:
 
 ```
-CURL -X GET 'http://localhost:8000?foo=bar'
+CURL -X GET 'http://localhost:8000/example?foo=bar'
 ```
 
 ## More options


### PR DESCRIPTION
Initial example CURL command does not include route to /example.
